### PR TITLE
Bugfix: Allow library users to create Select

### DIFF
--- a/src/Elemental/Form/Field/LongText.elm
+++ b/src/Elemental/Form/Field/LongText.elm
@@ -2,6 +2,7 @@ module Elemental.Form.Field.LongText exposing
     ( Flags
     , Model
     , Msg
+    , Msg_
     , Options
     , field
     )

--- a/src/Elemental/Form/Field/Select.elm
+++ b/src/Elemental/Form/Field/Select.elm
@@ -2,6 +2,7 @@ module Elemental.Form.Field.Select exposing
     ( Flags
     , Model
     , Msg
+    , Msg_
     , Options
     , field
     )


### PR DESCRIPTION
This PR exposes the Msg_ type on `Form.Field.ShortText`.

The `support` field required by `Form.Field.ShortText.Options` is of type `Field.Support (Select.Msg_ value)`, but since the `Msg_` type is not exposed, we cannot create type definitions containing the `support` field.