### PR TITLE
Improvement: Move input spacer multiples to widget theme

### DIFF
--- a/src/Elemental/Form/Field/LongText.elm
+++ b/src/Elemental/Form/Field/LongText.elm
@@ -78,10 +78,6 @@ type alias Options_ =
     { widgetTheme : Textarea.Theme
     , placeholder : String
     , height : Float
-    , spacerMultiples :
-        { x : Float
-        , y : Float
-        }
     }
 
 
@@ -100,6 +96,7 @@ view options model =
                 , foreground = fieldColors.foreground
                 }
             , borderRadius = options.widgetTheme.borderRadius
+            , spacerMultiples = options.widgetTheme.spacerMultiples
             }
         , layout = options.layout
         , disabled = options.disabled
@@ -107,6 +104,5 @@ view options model =
         , placeholder = options.placeholder
         , height = options.height
         , onInput = ChangedInput
-        , spacerMultiples = options.spacerMultiples
         }
         model.value

--- a/src/Elemental/Form/Field/ShortText.elm
+++ b/src/Elemental/Form/Field/ShortText.elm
@@ -86,10 +86,6 @@ type alias Options_ =
     , icon : Maybe Icon
     , placeholder : String
     , autofocus : Bool
-    , spacerMultiples :
-        { x : Input.Size -> Float
-        , y : Input.Size -> Float
-        }
     }
 
 
@@ -108,6 +104,7 @@ view options model =
                 , foreground = fieldColors.foreground
                 }
             , borderRadius = options.widgetTheme.borderRadius
+            , spacerMultiples = options.widgetTheme.spacerMultiples
             }
         , layout = options.layout
         , type_ = options.type_
@@ -119,6 +116,5 @@ view options model =
         , placeholder = options.placeholder
         , onInput = ChangedInput
         , customAttrs = []
-        , spacerMultiples = options.spacerMultiples
         }
         model.value

--- a/src/Elemental/Form/Field/Switch.elm
+++ b/src/Elemental/Form/Field/Switch.elm
@@ -77,9 +77,6 @@ type alias Options_ =
     { widgetTheme : Switch.Theme
     , switchText : String
     , size : Switch.Size
-    , spacerMultiples :
-        { y : Switch.Size -> Float
-        }
     }
 
 
@@ -91,7 +88,6 @@ view options model =
         , text = options.switchText
         , disabled = options.disabled
         , size = options.size
-        , spacerMultiples = options.spacerMultiples
         , onToggle = ToggledSwitch
         }
         model.value

--- a/src/Elemental/Form/Field/Switch.elm
+++ b/src/Elemental/Form/Field/Switch.elm
@@ -77,6 +77,9 @@ type alias Options_ =
     { widgetTheme : Switch.Theme
     , switchText : String
     , size : Switch.Size
+    , spacerMultiples :
+        { y : Switch.Size -> Float
+        }
     }
 
 
@@ -88,7 +91,7 @@ view options model =
         , text = options.switchText
         , disabled = options.disabled
         , size = options.size
-        , verticalPadding = \_ -> 2
+        , spacerMultiples = options.spacerMultiples
         , onToggle = ToggledSwitch
         }
         model.value

--- a/src/Elemental/Form/Field/Switch.elm
+++ b/src/Elemental/Form/Field/Switch.elm
@@ -1,0 +1,94 @@
+module Elemental.Form.Field.Switch exposing
+    ( Flags
+    , Model
+    , Msg
+    , Options
+    , field
+    )
+
+import Elemental.Form.Field as Field
+import Elemental.View.Form.Field.Switch as Switch
+import Html.Styled as H
+
+
+type alias Field =
+    Field.Field {} {} Msg_ Options_ Bool
+
+
+field : Field
+field =
+    Field.build
+        { init = init
+        , update = update
+        , view = view
+        }
+
+
+
+-- MODEL
+
+
+type alias Flags =
+    Field.Flags {} Bool
+
+
+type alias Model =
+    Field.Model {} Bool
+
+
+init : Flags -> ( Model, Cmd Msg_ )
+init flags =
+    ( { value = flags.value
+      , validator = flags.validator
+      , errors = []
+      }
+    , Cmd.none
+    )
+
+
+
+-- UPDATE
+
+
+type alias Msg =
+    Field.Msg Msg_
+
+
+type Msg_
+    = ToggledSwitch Bool
+
+
+update : Msg_ -> Model -> ( Model, Cmd Msg_ )
+update msg model =
+    case msg of
+        ToggledSwitch newValue ->
+            ( { model | value = newValue }, Cmd.none )
+
+
+
+-- VIEW
+
+
+type alias Options =
+    Field.Options Msg_ Options_
+
+
+type alias Options_ =
+    { widgetTheme : Switch.Theme
+    , switchText : String
+    , size : Switch.Size
+    }
+
+
+view : Options -> Model -> H.Html Msg_
+view options model =
+    Switch.view
+        { theme = options.widgetTheme
+        , layout = options.layout
+        , text = options.switchText
+        , disabled = options.disabled
+        , size = options.size
+        , verticalPadding = \_ -> 2
+        , onToggle = ToggledSwitch
+        }
+        model.value

--- a/src/Elemental/View/Form/Field/Input.elm
+++ b/src/Elemental/View/Form/Field/Input.elm
@@ -28,10 +28,6 @@ type alias Options msg =
     , placeholder : String
     , onInput : String -> msg
     , customAttrs : List (H.Attribute msg)
-    , spacerMultiples :
-        { x : Size -> Float
-        , y : Size -> Float
-        }
     }
 
 
@@ -57,6 +53,10 @@ type alias Theme =
             }
         }
     , borderRadius : BorderRadius.Style
+    , spacerMultiples :
+        { y : Size -> Float
+        , x : Size -> Float
+        }
     }
 
 
@@ -190,9 +190,9 @@ view options value =
             else
                 normalInputStyle
 
-        ( leftRightMultiple, topBottomMultiple ) =
-            ( options.spacerMultiples.x options.size
-            , options.spacerMultiples.y options.size
+        ( topBottomMultiple, leftRightMultiple ) =
+            ( options.theme.spacerMultiples.y options.size
+            , options.theme.spacerMultiples.x options.size
             )
 
         topBottomPadding =

--- a/src/Elemental/View/Form/Field/Select.elm
+++ b/src/Elemental/View/Form/Field/Select.elm
@@ -59,12 +59,12 @@ type alias Theme =
             , value : Css.Color
             }
         }
+    , borderRadius : BorderRadius.Style
     , spacerMultiples :
         { y : Float
         , x : Float
         , caret : Float
         }
-    , borderRadius : BorderRadius.Style
     }
 
 

--- a/src/Elemental/View/Form/Field/Switch.elm
+++ b/src/Elemental/View/Form/Field/Switch.elm
@@ -1,0 +1,315 @@
+module Elemental.View.Form.Field.Switch exposing
+    ( Options
+    , Size(..)
+    , Theme
+    , view
+    )
+
+import Css
+import Css.Transitions
+import Elemental.Css as LibCss
+import Elemental.Layout as L
+import Elemental.Typography as Typography exposing (Typography)
+import Html.Styled as H
+import Html.Styled.Attributes as HA
+import Html.Styled.Events as Events
+
+
+type alias Options msg =
+    { theme : Theme
+    , layout : L.Layout msg
+    , text : String
+    , disabled : Bool
+    , size : Size
+    , verticalPadding : Size -> Float
+    , onToggle : Bool -> msg
+    }
+
+
+type Size
+    = Small
+    | Medium
+
+
+type alias Theme =
+    { colors :
+        { background :
+            { disabled : Css.Color
+            , off : Css.Color
+            , on : Css.Color
+            }
+        , border :
+            { disabled : Css.Color
+            , off : Css.Color
+            , on : Css.Color
+            }
+        , foreground :
+            { enabled : Css.Color
+            , disabled : Css.Color
+            }
+        , handle :
+            { background :
+                { disabled : Css.Color
+                , off : Css.Color
+                , on : Css.Color
+                }
+            , border :
+                { disabled : Css.Color
+                , off : Css.Color
+                , on : Css.Color
+                }
+            }
+        }
+    , typography :
+        { label : Typography
+        }
+    , transitionDuration : Float
+    }
+
+
+view : Options msg -> Bool -> H.Html msg
+view options isSelected =
+    let
+        ( width, height ) =
+            case options.size of
+                Small ->
+                    ( 34, 20 )
+
+                Medium ->
+                    ( 42, 24 )
+
+        dimensions =
+            ( width, height )
+
+        attrs =
+            [ HA.css
+                [ Css.width <| Css.px width
+                , Css.height <| Css.px height
+                , Css.position Css.relative
+                ]
+            ]
+    in
+    L.viewColumn
+        L.Normal
+        []
+        [ options.layout.spacerY <|
+            options.verticalPadding options.size
+        , L.viewRow
+            L.Normal
+            []
+            [ H.div attrs
+                [ viewInput options dimensions isSelected
+                , viewHandle options dimensions isSelected
+                ]
+            , viewLabel options isSelected
+            ]
+        , options.layout.spacerY <|
+            options.verticalPadding options.size
+        ]
+
+
+viewInput : Options msg -> ( Float, Float ) -> Bool -> H.Html msg
+viewInput options ( width, height ) isSelected =
+    let
+        fieldColors =
+            options.theme.colors
+
+        transitionDuration =
+            options.theme.transitionDuration
+
+        disabledStyle =
+            Css.batch
+                [ Css.backgroundColor fieldColors.background.disabled
+                , LibCss.borderAll fieldColors.border.disabled
+                ]
+
+        normalStyle =
+            Css.batch
+                [ Css.backgroundColor <|
+                    if isSelected then
+                        fieldColors.background.on
+
+                    else
+                        fieldColors.background.off
+                , LibCss.borderAll <|
+                    if isSelected then
+                        fieldColors.border.on
+
+                    else
+                        fieldColors.border.off
+                , Css.Transitions.transition
+                    [ Css.Transitions.left transitionDuration
+                    , Css.Transitions.background transitionDuration
+                    , Css.Transitions.borderColor transitionDuration
+                    ]
+                ]
+
+        interactionStyle =
+            if options.disabled then
+                disabledStyle
+
+            else
+                normalStyle
+
+        css =
+            HA.css
+                [ Css.width <| Css.px width
+                , Css.height <| Css.px height
+                , Css.borderRadius <| Css.px (height / 2)
+                , interactionStyle
+                ]
+
+        baseAttrs =
+            [ HA.type_ "checkbox"
+            , HA.disabled options.disabled
+            , HA.checked isSelected
+            , css
+            ]
+
+        additionalAttrs =
+            if options.disabled then
+                [ HA.css
+                    [ Css.cursor Css.notAllowed
+                    ]
+                ]
+
+            else
+                [ Events.onCheck options.onToggle
+                , HA.css
+                    [ Css.cursor Css.pointer
+                    ]
+                ]
+
+        attrs =
+            baseAttrs ++ additionalAttrs
+    in
+    H.input attrs []
+
+
+viewHandle : Options msg -> ( Float, Float ) -> Bool -> H.Html msg
+viewHandle options ( width, height ) isSelected =
+    let
+        fieldColors =
+            options.theme.colors
+
+        transitionDuration =
+            options.theme.transitionDuration
+
+        handlePadding =
+            3
+
+        size =
+            height - (2 * handlePadding)
+
+        disabledStyle =
+            Css.batch
+                [ Css.backgroundColor fieldColors.handle.background.disabled
+                , LibCss.borderAll fieldColors.handle.border.disabled
+                ]
+
+        normalStyle =
+            Css.batch
+                [ Css.backgroundColor <|
+                    if isSelected then
+                        fieldColors.handle.background.on
+
+                    else
+                        fieldColors.handle.background.off
+                , LibCss.borderAll <|
+                    if isSelected then
+                        fieldColors.handle.border.on
+
+                    else
+                        fieldColors.handle.border.off
+                , Css.Transitions.transition
+                    [ Css.Transitions.left transitionDuration
+                    , Css.Transitions.background transitionDuration
+                    , Css.Transitions.borderColor transitionDuration
+                    ]
+                ]
+
+        css =
+            Css.batch
+                [ Css.width <| Css.px size
+                , Css.height <| Css.px size
+                , Css.borderRadius (Css.px (size / 2))
+                , Css.border2 (Css.px 1) Css.solid
+                , Css.left <|
+                    if isSelected then
+                        Css.px (width - handlePadding - size)
+
+                    else
+                        Css.px handlePadding
+                , Css.top <| Css.px handlePadding
+                , Css.position Css.absolute
+                , Css.pointerEvents Css.none
+                ]
+
+        handleAttr =
+            [ HA.css
+                [ css
+                , if options.disabled then
+                    disabledStyle
+
+                  else
+                    normalStyle
+                ]
+            ]
+    in
+    H.span handleAttr []
+
+
+viewLabel : Options msg -> Bool -> H.Html msg
+viewLabel options currentValue =
+    if String.isEmpty options.text then
+        viewEmptyLabel
+
+    else
+        viewNonEmptyLabel options currentValue
+
+
+viewEmptyLabel : H.Html msg
+viewEmptyLabel =
+    H.text ""
+
+
+viewNonEmptyLabel : Options msg -> Bool -> H.Html msg
+viewNonEmptyLabel options currentValue =
+    let
+        labelColors =
+            options.theme.colors.foreground
+
+        labelTypography =
+            Typography.toStyle options.theme.typography.label
+
+        labelStyle =
+            [ labelTypography
+            , Css.batch <|
+                if options.disabled then
+                    [ Css.cursor Css.notAllowed
+                    , Css.color labelColors.disabled
+                    ]
+
+                else
+                    [ Css.cursor Css.pointer
+                    , Css.color labelColors.enabled
+                    ]
+            ]
+
+        interactionAttr =
+            if options.disabled then
+                []
+
+            else
+                [ Events.onClick <|
+                    options.onToggle (not currentValue)
+                ]
+    in
+    H.div interactionAttr
+        [ L.viewRow
+            L.Normal
+            labelStyle
+            [ options.layout.spacerX 2
+            , H.text options.text
+            ]
+        ]

--- a/src/Elemental/View/Form/Field/Switch.elm
+++ b/src/Elemental/View/Form/Field/Switch.elm
@@ -21,7 +21,9 @@ type alias Options msg =
     , text : String
     , disabled : Bool
     , size : Size
-    , verticalPadding : Size -> Float
+    , spacerMultiples :
+        { y : Size -> Float
+        }
     , onToggle : Bool -> msg
     }
 
@@ -93,7 +95,7 @@ view options isSelected =
         L.Normal
         []
         [ options.layout.spacerY <|
-            options.verticalPadding options.size
+            options.spacerMultiples.y options.size
         , L.viewRow
             L.Normal
             []
@@ -104,7 +106,7 @@ view options isSelected =
             , viewLabel options isSelected
             ]
         , options.layout.spacerY <|
-            options.verticalPadding options.size
+            options.spacerMultiples.y options.size
         ]
 
 

--- a/src/Elemental/View/Form/Field/Switch.elm
+++ b/src/Elemental/View/Form/Field/Switch.elm
@@ -21,9 +21,6 @@ type alias Options msg =
     , text : String
     , disabled : Bool
     , size : Size
-    , spacerMultiples :
-        { y : Size -> Float
-        }
     , onToggle : Bool -> msg
     }
 
@@ -62,10 +59,14 @@ type alias Theme =
                 }
             }
         }
+    , spacerMultiples :
+        { y : Size -> Float
+        , text : Size -> Float
+        }
+    , transitionDuration : Float
     , typography :
         { label : Typography
         }
-    , transitionDuration : Float
     }
 
 
@@ -95,7 +96,7 @@ view options isSelected =
         L.Normal
         []
         [ options.layout.spacerY <|
-            options.spacerMultiples.y options.size
+            options.theme.spacerMultiples.y options.size
         , L.viewRow
             L.Normal
             []
@@ -103,10 +104,12 @@ view options isSelected =
                 [ viewInput options dimensions isSelected
                 , viewHandle options dimensions isSelected
                 ]
+            , options.layout.spacerX <|
+                options.theme.spacerMultiples.text options.size
             , viewLabel options isSelected
             ]
         , options.layout.spacerY <|
-            options.spacerMultiples.y options.size
+            options.theme.spacerMultiples.y options.size
         ]
 
 
@@ -311,7 +314,8 @@ viewNonEmptyLabel options currentValue =
         [ L.viewRow
             L.Normal
             labelStyle
-            [ options.layout.spacerX 2
+            [ options.layout.spacerX <|
+                options.theme.spacerMultiples.text options.size
             , H.text options.text
             ]
         ]

--- a/src/Elemental/View/Form/Field/Textarea.elm
+++ b/src/Elemental/View/Form/Field/Textarea.elm
@@ -17,10 +17,6 @@ type alias Options msg =
     , placeholder : String
     , height : Float
     , onInput : String -> msg
-    , spacerMultiples :
-        { x : Float
-        , y : Float
-        }
     }
 
 
@@ -46,6 +42,10 @@ type alias Theme =
             }
         }
     , borderRadius : BorderRadius.Style
+    , spacerMultiples :
+        { y : Float
+        , x : Float
+        }
     }
 
 
@@ -112,8 +112,8 @@ view options value =
                 , Css.height <| Css.px options.height
                 , Css.resize Css.vertical
                 , Css.padding2
-                    (options.layout.computeSpacerPx options.spacerMultiples.y)
-                    (options.layout.computeSpacerPx options.spacerMultiples.x)
+                    (options.layout.computeSpacerPx options.theme.spacerMultiples.y)
+                    (options.layout.computeSpacerPx options.theme.spacerMultiples.x)
                 , BorderRadius.toCssStyle options.theme.borderRadius
                 , style
                 ]


### PR DESCRIPTION
Also arranges, spacers in `(y,x)` order instead of `(x,y)` to match the convention in `Select` and the order found in `Css.padding2`