### PR TITLE
Improvement: Move spacerMultiples into component themes

### DIFF
--- a/src/Elemental/Form/Field/LongText.elm
+++ b/src/Elemental/Form/Field/LongText.elm
@@ -78,10 +78,6 @@ type alias Options_ =
     { widgetTheme : Textarea.Theme
     , placeholder : String
     , height : Float
-    , spacerMultiples :
-        { x : Float
-        , y : Float
-        }
     }
 
 
@@ -100,6 +96,7 @@ view options model =
                 , foreground = fieldColors.foreground
                 }
             , borderRadius = options.widgetTheme.borderRadius
+            , spacerMultiples = options.widgetTheme.spacerMultiples
             }
         , layout = options.layout
         , disabled = options.disabled
@@ -107,6 +104,5 @@ view options model =
         , placeholder = options.placeholder
         , height = options.height
         , onInput = ChangedInput
-        , spacerMultiples = options.spacerMultiples
         }
         model.value

--- a/src/Elemental/Form/Field/ShortText.elm
+++ b/src/Elemental/Form/Field/ShortText.elm
@@ -86,10 +86,6 @@ type alias Options_ =
     , icon : Maybe Icon
     , placeholder : String
     , autofocus : Bool
-    , spacerMultiples :
-        { x : Input.Size -> Float
-        , y : Input.Size -> Float
-        }
     }
 
 
@@ -108,6 +104,7 @@ view options model =
                 , foreground = fieldColors.foreground
                 }
             , borderRadius = options.widgetTheme.borderRadius
+            , spacerMultiples = options.widgetTheme.spacerMultiples
             }
         , layout = options.layout
         , type_ = options.type_
@@ -119,6 +116,5 @@ view options model =
         , placeholder = options.placeholder
         , onInput = ChangedInput
         , customAttrs = []
-        , spacerMultiples = options.spacerMultiples
         }
         model.value

--- a/src/Elemental/View/Form/Field/Input.elm
+++ b/src/Elemental/View/Form/Field/Input.elm
@@ -28,10 +28,6 @@ type alias Options msg =
     , placeholder : String
     , onInput : String -> msg
     , customAttrs : List (H.Attribute msg)
-    , spacerMultiples :
-        { x : Size -> Float
-        , y : Size -> Float
-        }
     }
 
 
@@ -57,6 +53,10 @@ type alias Theme =
             }
         }
     , borderRadius : BorderRadius.Style
+    , spacerMultiples :
+        { y : Size -> Float
+        , x : Size -> Float
+        }
     }
 
 
@@ -190,9 +190,9 @@ view options value =
             else
                 normalInputStyle
 
-        ( leftRightMultiple, topBottomMultiple ) =
-            ( options.spacerMultiples.x options.size
-            , options.spacerMultiples.y options.size
+        ( topBottomMultiple, leftRightMultiple ) =
+            ( options.theme.spacerMultiples.y options.size
+            , options.theme.spacerMultiples.x options.size
             )
 
         topBottomPadding =

--- a/src/Elemental/View/Form/Field/Select.elm
+++ b/src/Elemental/View/Form/Field/Select.elm
@@ -59,12 +59,12 @@ type alias Theme =
             , value : Css.Color
             }
         }
+    , borderRadius : BorderRadius.Style
     , spacerMultiples :
         { y : Float
         , x : Float
         , caret : Float
         }
-    , borderRadius : BorderRadius.Style
     }
 
 

--- a/src/Elemental/View/Form/Field/Textarea.elm
+++ b/src/Elemental/View/Form/Field/Textarea.elm
@@ -17,10 +17,6 @@ type alias Options msg =
     , placeholder : String
     , height : Float
     , onInput : String -> msg
-    , spacerMultiples :
-        { x : Float
-        , y : Float
-        }
     }
 
 
@@ -46,6 +42,10 @@ type alias Theme =
             }
         }
     , borderRadius : BorderRadius.Style
+    , spacerMultiples :
+        { y : Float
+        , x : Float
+        }
     }
 
 
@@ -112,8 +112,8 @@ view options value =
                 , Css.height <| Css.px options.height
                 , Css.resize Css.vertical
                 , Css.padding2
-                    (options.layout.computeSpacerPx options.spacerMultiples.y)
-                    (options.layout.computeSpacerPx options.spacerMultiples.x)
+                    (options.layout.computeSpacerPx options.theme.spacerMultiples.y)
+                    (options.layout.computeSpacerPx options.theme.spacerMultiples.x)
                 , BorderRadius.toCssStyle options.theme.borderRadius
                 , style
                 ]


### PR DESCRIPTION
Also arranges spacers in (y,x) order instead of (x,y) to match the convention in Select and the order found in Css.padding2