### PR TITLE
Bugfix: Remove double spacing in Switch

### DIFF
--- a/src/Elemental/View/Form/Field/Switch.elm
+++ b/src/Elemental/View/Form/Field/Switch.elm
@@ -104,8 +104,6 @@ view options isSelected =
                 [ viewInput options dimensions isSelected
                 , viewHandle options dimensions isSelected
                 ]
-            , options.layout.spacerX <|
-                options.theme.spacerMultiples.text options.size
             , viewLabel options isSelected
             ]
         , options.layout.spacerY <|


### PR DESCRIPTION
Looks like I added two spacers between the input and the text🤦‍♂️. This PR removes the non-clickable one.

Good news is that the specimen page definitely helps in debugging the UI 🙂.