### PR TITLE
Bugfix: Fix View.Form.Field.Select height when no choice is selected

### DIFF
--- a/src/Elemental/View/Form/Field/Select.elm
+++ b/src/Elemental/View/Form/Field/Select.elm
@@ -91,6 +91,11 @@ view options value =
             Maybe.map .text selectedChoice
                 |> Maybe.withDefault " "
 
+        hasSelectedText =
+            Maybe.map .text selectedChoice
+                |> Maybe.map (always True)
+                |> Maybe.withDefault False
+
         fieldColors =
             options.theme.colors
 
@@ -171,7 +176,11 @@ view options value =
             [ LibCss.grow
             , Css.overflow Css.hidden
             , Css.textOverflow Css.ellipsis
-            , Css.whiteSpace Css.noWrap
+            , if hasSelectedText then
+                Css.whiteSpace Css.noWrap
+
+              else
+                Css.whiteSpace Css.pre
             ]
             [ Html.text selectedText ]
         , options.layout.spacerX options.theme.spacerMultiples.caret

--- a/src/Elemental/View/Form/Field/Select.elm
+++ b/src/Elemental/View/Form/Field/Select.elm
@@ -14,6 +14,7 @@ import Elemental.Layout as Layout exposing (Layout)
 import Html.Styled as Html exposing (Html)
 import Html.Styled.Attributes as Attrs
 import Html.Styled.Events as Events
+import Lib.Maybe as Maybe
 import Svg.Styled as Svg
 import Svg.Styled.Attributes as SvgAttrs
 
@@ -92,9 +93,7 @@ view options value =
                 |> Maybe.withDefault " "
 
         hasSelectedText =
-            Maybe.map .text selectedChoice
-                |> Maybe.map (always True)
-                |> Maybe.withDefault False
+            Maybe.toBool selectedChoice
 
         fieldColors =
             options.theme.colors


### PR DESCRIPTION
Whitespace is treated differently from other characters in HTML. 

This PR sets the `whitespace` property to `pre` when no choice is selected to treat the blank space like ordinary text.