### PR TITLE
Improve error label on form fields

### DIFF
--- a/src/Elemental/Form/Field.elm
+++ b/src/Elemental/Form/Field.elm
@@ -10,6 +10,7 @@ module Elemental.Form.Field exposing
     , hasError
     )
 
+import Css
 import Elemental.Form.Validate as V exposing (Validator)
 import Elemental.Layout as L
 import Elemental.View.Form.Field as Field
@@ -61,6 +62,7 @@ type alias Options msg options =
         , support : Field.Support msg
         , required : Bool
         , disabled : Bool
+        , errorIcon : Maybe (Css.Color -> H.Html msg)
     }
 
 
@@ -163,6 +165,7 @@ view viewField options model =
         , required = options.required
         , disabled = options.disabled
         , errors = model.errors
+        , errorIcon = options.errorIcon
         }
         viewWidget
         |> H.map FieldChanged

--- a/src/Elemental/Form/Field.elm
+++ b/src/Elemental/Form/Field.elm
@@ -62,7 +62,7 @@ type alias Options msg options =
         , support : Field.Support msg
         , required : Bool
         , disabled : Bool
-        , errorIcon : Maybe (Css.Color -> H.Html msg)
+        , maybeToErrorIcon : Maybe (Css.Color -> H.Html msg)
     }
 
 
@@ -165,7 +165,7 @@ view viewField options model =
         , required = options.required
         , disabled = options.disabled
         , errors = model.errors
-        , errorIcon = options.errorIcon
+        , maybeToErrorIcon = options.maybeToErrorIcon
         }
         viewWidget
         |> H.map FieldChanged

--- a/src/Elemental/View/Form/Field.elm
+++ b/src/Elemental/View/Form/Field.elm
@@ -20,7 +20,7 @@ type alias Options msg =
     , required : Bool
     , disabled : Bool
     , errors : List String
-    , errorIcon : Maybe (Css.Color -> H.Html msg)
+    , maybeToErrorIcon : Maybe (Css.Color -> H.Html msg)
     }
 
 
@@ -58,14 +58,14 @@ view options viewWidget =
     L.viewColumn
         L.Normal
         []
-        [ viewLabel options.theme options.layout options.required hasError options.errorIcon options.label
+        [ viewLabel options.theme options.layout options.required hasError options.maybeToErrorIcon options.label
         , viewWidget
         , viewSupportOrErrorMessages
         ]
 
 
 viewLabel : Theme -> L.Layout msg -> Bool -> Bool -> Maybe (Css.Color -> H.Html msg) -> String -> H.Html msg
-viewLabel theme layout isRequired hasError maybeErrorIcon text =
+viewLabel theme layout isRequired hasError maybeToErrorIcon text =
     if String.isEmpty text then
         viewEmptyLabel
 
@@ -73,7 +73,7 @@ viewLabel theme layout isRequired hasError maybeErrorIcon text =
         L.viewColumn
             L.Normal
             []
-            [ viewNonEmptyLabel theme layout isRequired hasError maybeErrorIcon text
+            [ viewNonEmptyLabel theme layout isRequired hasError maybeToErrorIcon text
             , layout.spacerY 2
             ]
 
@@ -84,7 +84,7 @@ viewEmptyLabel =
 
 
 viewNonEmptyLabel : Theme -> L.Layout msg -> Bool -> Bool -> Maybe (Css.Color -> H.Html msg) -> String -> H.Html msg
-viewNonEmptyLabel theme layout isRequired hasError maybeErrorIcon text =
+viewNonEmptyLabel theme layout isRequired hasError maybeToErrorIcon text =
     let
         labelTypographyStyle =
             Typography.toStyle theme.typography.label
@@ -101,7 +101,7 @@ viewNonEmptyLabel theme layout isRequired hasError maybeErrorIcon text =
         [ L.viewRow
             L.Left
             []
-            [ viewErrorIcon theme layout hasError maybeErrorIcon
+            [ viewErrorIcon theme layout hasError maybeToErrorIcon
             , H.text text
             , viewStar theme layout isRequired
             ]
@@ -126,13 +126,13 @@ viewStar theme layout isRequired =
         H.text ""
 
 viewErrorIcon : Theme -> L.Layout msg -> Bool -> Maybe (Css.Color -> H.Html msg) -> H.Html msg
-viewErrorIcon theme layout hasError maybeIcon =
-    case (maybeIcon, hasError) of
-        (Just icon, True) ->
+viewErrorIcon theme layout hasError maybeToErrorIcon =
+    case (maybeToErrorIcon, hasError) of
+        (Just toErrorIcon, True) ->
             L.viewRow
                 L.Center
                 []
-                [ icon theme.colors.error
+                [ toErrorIcon theme.colors.error
                 , layout.spacerX 1
                 ]
 

--- a/src/Elemental/View/Form/Field.elm
+++ b/src/Elemental/View/Form/Field.elm
@@ -20,6 +20,7 @@ type alias Options msg =
     , required : Bool
     , disabled : Bool
     , errors : List String
+    , errorIcon : Maybe (Css.Color -> H.Html msg)
     }
 
 
@@ -57,14 +58,14 @@ view options viewWidget =
     L.viewColumn
         L.Normal
         []
-        [ viewLabel options.theme options.layout options.required options.label
+        [ viewLabel options.theme options.layout options.required hasError options.errorIcon options.label
         , viewWidget
         , viewSupportOrErrorMessages
         ]
 
 
-viewLabel : Theme -> L.Layout msg -> Bool -> String -> H.Html msg
-viewLabel theme layout isRequired text =
+viewLabel : Theme -> L.Layout msg -> Bool -> Bool -> Maybe (Css.Color -> H.Html msg) -> String -> H.Html msg
+viewLabel theme layout isRequired hasError maybeErrorIcon text =
     if String.isEmpty text then
         viewEmptyLabel
 
@@ -72,7 +73,7 @@ viewLabel theme layout isRequired text =
         L.viewColumn
             L.Normal
             []
-            [ viewNonEmptyLabel theme layout isRequired text
+            [ viewNonEmptyLabel theme layout isRequired hasError maybeErrorIcon text
             , layout.spacerY 2
             ]
 
@@ -82,18 +83,26 @@ viewEmptyLabel =
     H.text ""
 
 
-viewNonEmptyLabel : Theme -> L.Layout msg -> Bool -> String -> H.Html msg
-viewNonEmptyLabel theme layout isRequired text =
+viewNonEmptyLabel : Theme -> L.Layout msg -> Bool -> Bool -> Maybe (Css.Color -> H.Html msg) -> String -> H.Html msg
+viewNonEmptyLabel theme layout isRequired hasError maybeErrorIcon text =
     let
-        labelStyle =
+        labelTypographyStyle =
             Typography.toStyle theme.typography.label
+                
+        labelStyle =
+            if hasError then
+                [ labelTypographyStyle, Css.color theme.colors.error ]
+
+            else
+                [ labelTypographyStyle ]
     in
     H.div
-        [ HA.css [ labelStyle ] ]
+        [ HA.css labelStyle ]
         [ L.viewRow
             L.Left
             []
-            [ H.text text
+            [ viewErrorIcon theme layout hasError maybeErrorIcon
+            , H.text text
             , viewStar theme layout isRequired
             ]
         ]
@@ -115,6 +124,20 @@ viewStar theme layout isRequired =
 
     else
         H.text ""
+
+viewErrorIcon : Theme -> L.Layout msg -> Bool -> Maybe (Css.Color -> H.Html msg) -> H.Html msg
+viewErrorIcon theme layout hasError maybeIcon =
+    case (maybeIcon, hasError) of
+        (Just icon, True) ->
+            L.viewRow
+                L.Center
+                []
+                [ icon theme.colors.error
+                , layout.spacerX 1
+                ]
+
+        _ ->
+            H.text ""
 
 
 viewSupport : Theme -> L.Layout msg -> Support msg -> H.Html msg


### PR DESCRIPTION
- Add support for an error icon that is only visible when the field has an error
- Apply the error color to the label when the field has an error

From the examples branch:
![image](https://user-images.githubusercontent.com/28830783/214562035-e9d52362-8120-40ae-8834-f1d128d001e9.png)