### PR TITLE
Implement input interaction tracking

### DIFF
--- a/src/Elemental/Form/Field/LongText.elm
+++ b/src/Elemental/Form/Field/LongText.elm
@@ -8,6 +8,7 @@ module Elemental.Form.Field.LongText exposing
     )
 
 import Elemental.Form.Field as Field
+import Elemental.Form.Interaction as Interaction exposing (Interaction)
 import Elemental.View.Form.Field.Textarea as Textarea
 import Html.Styled as H
 
@@ -57,13 +58,17 @@ type alias Msg =
 
 type Msg_
     = ChangedInput String
+    | UserInteracted Interaction
 
 
-update : Msg_ -> Model -> ( Model, Cmd Msg_ )
+update : Msg_ -> Model -> ( Model, Cmd Msg_, Maybe Interaction )
 update msg model =
     case msg of
         ChangedInput newValue ->
-            ( { model | value = newValue }, Cmd.none )
+            ( { model | value = newValue }, Cmd.none, Nothing )
+
+        UserInteracted interaction ->
+            ( model, Cmd.none, Just interaction )
 
 
 
@@ -104,5 +109,7 @@ view options model =
         , placeholder = options.placeholder
         , height = options.height
         , onInput = ChangedInput
+        , maybeConfig =
+            Just <| Interaction.config UserInteracted options.userInteractions
         }
         model.value

--- a/src/Elemental/Form/Field/LongText.elm
+++ b/src/Elemental/Form/Field/LongText.elm
@@ -8,7 +8,7 @@ module Elemental.Form.Field.LongText exposing
     )
 
 import Elemental.Form.Field as Field
-import Elemental.Form.Interaction as Interaction
+import Elemental.Form.Interaction as Interaction exposing (Interaction)
 import Elemental.View.Form.Field.Textarea as Textarea
 import Html.Styled as H
 

--- a/src/Elemental/Form/Field/LongText.elm
+++ b/src/Elemental/Form/Field/LongText.elm
@@ -8,7 +8,7 @@ module Elemental.Form.Field.LongText exposing
     )
 
 import Elemental.Form.Field as Field
-import Elemental.Form.Interaction as Interaction exposing (Interaction)
+import Elemental.Form.Interaction as Interaction
 import Elemental.View.Form.Field.Textarea as Textarea
 import Html.Styled as H
 
@@ -109,7 +109,7 @@ view options model =
         , placeholder = options.placeholder
         , height = options.height
         , onInput = ChangedInput
-        , maybeConfig =
+        , maybeInteractionConfig =
             Just <| Interaction.config UserInteracted options.userInteractions
         }
         model.value

--- a/src/Elemental/Form/Field/LongText.elm
+++ b/src/Elemental/Form/Field/LongText.elm
@@ -110,6 +110,6 @@ view options model =
         , height = options.height
         , onInput = ChangedInput
         , maybeInteractionConfig =
-            Just <| Interaction.config UserInteracted options.userInteractions
+            Interaction.toConfig UserInteracted options.userInteractions
         }
         model.value

--- a/src/Elemental/Form/Field/Select.elm
+++ b/src/Elemental/Form/Field/Select.elm
@@ -99,7 +99,7 @@ view options model =
         , disabled = options.disabled
         , error = Field.hasError model
         , onInput = ChangedInput
-        , maybeOnInteraction =
+        , maybeInteractionConfig =
             Just <| Interaction.config UserInteracted options.userInteractions
         , viewCaret = options.viewCaret
         , choices = options.choices

--- a/src/Elemental/Form/Field/Select.elm
+++ b/src/Elemental/Form/Field/Select.elm
@@ -100,7 +100,7 @@ view options model =
         , error = Field.hasError model
         , onInput = ChangedInput
         , maybeInteractionConfig =
-            Just <| Interaction.config UserInteracted options.userInteractions
+            Interaction.toConfig UserInteracted options.userInteractions
         , viewCaret = options.viewCaret
         , choices = options.choices
         , customAttrs = []

--- a/src/Elemental/Form/Field/Select.elm
+++ b/src/Elemental/Form/Field/Select.elm
@@ -8,6 +8,7 @@ module Elemental.Form.Field.Select exposing
     )
 
 import Elemental.Form.Field as Field
+import Elemental.Form.Interaction as Interaction exposing (Interaction)
 import Elemental.View.Form.Field.Select as Select
 import Html.Styled as Html exposing (Html)
 
@@ -57,16 +58,20 @@ type alias Msg value =
 
 type Msg_ value
     = ChangedInput (Maybe value)
+    | UserInteracted Interaction
 
 
-update : Msg_ value -> Model value -> ( Model value, Cmd (Msg_ value) )
+update : Msg_ value -> Model value -> ( Model value, Cmd (Msg_ value), Maybe Interaction )
 update msg model =
     case msg of
         ChangedInput Nothing ->
-            ( model, Cmd.none )
+            ( model, Cmd.none, Nothing )
 
         ChangedInput (Just newValue) ->
-            ( { model | value = newValue }, Cmd.none )
+            ( { model | value = newValue }, Cmd.none, Nothing )
+
+        UserInteracted interaction ->
+            ( model, Cmd.none, Just interaction )
 
 
 
@@ -94,6 +99,8 @@ view options model =
         , disabled = options.disabled
         , error = Field.hasError model
         , onInput = ChangedInput
+        , maybeOnInteraction =
+            Just <| Interaction.config UserInteracted options.userInteractions
         , viewCaret = options.viewCaret
         , choices = options.choices
         , customAttrs = []

--- a/src/Elemental/Form/Field/ShortText.elm
+++ b/src/Elemental/Form/Field/ShortText.elm
@@ -122,7 +122,7 @@ view options model =
         , placeholder = options.placeholder
         , onInput = ChangedInput
         , maybeInteractionConfig =
-            Just <| Interaction.config UserInteracted options.userInteractions
+            Interaction.toConfig UserInteracted options.userInteractions
         , customAttrs = options.customAttrs
         }
         model.value

--- a/src/Elemental/Form/Field/ShortText.elm
+++ b/src/Elemental/Form/Field/ShortText.elm
@@ -9,6 +9,7 @@ module Elemental.Form.Field.ShortText exposing
     )
 
 import Elemental.Form.Field as Field
+import Elemental.Form.Interaction as Interaction exposing (Interaction)
 import Elemental.View.Form.Field.Input as Input
 import Html.Styled as H
 
@@ -58,13 +59,17 @@ type alias Msg =
 
 type Msg_
     = ChangedInput String
+    | UserInteracted Interaction
 
 
-update : Msg_ -> Model -> ( Model, Cmd Msg_ )
+update : Msg_ -> Model -> ( Model, Cmd Msg_, Maybe Interaction )
 update msg model =
     case msg of
         ChangedInput newValue ->
-            ( { model | value = newValue }, Cmd.none )
+            ( { model | value = newValue }, Cmd.none, Nothing )
+
+        UserInteracted interaction ->
+            ( model, Cmd.none, Just interaction )
 
 
 
@@ -116,6 +121,8 @@ view options model =
         , error = Field.hasError model
         , placeholder = options.placeholder
         , onInput = ChangedInput
+        , maybeOnInteraction =
+            Just <| Interaction.config UserInteracted options.userInteractions
         , customAttrs = options.customAttrs
         }
         model.value

--- a/src/Elemental/Form/Field/ShortText.elm
+++ b/src/Elemental/Form/Field/ShortText.elm
@@ -121,7 +121,7 @@ view options model =
         , error = Field.hasError model
         , placeholder = options.placeholder
         , onInput = ChangedInput
-        , maybeOnInteraction =
+        , maybeInteractionConfig =
             Just <| Interaction.config UserInteracted options.userInteractions
         , customAttrs = options.customAttrs
         }

--- a/src/Elemental/Form/Field/Switch.elm
+++ b/src/Elemental/Form/Field/Switch.elm
@@ -8,6 +8,7 @@ module Elemental.Form.Field.Switch exposing
     )
 
 import Elemental.Form.Field as Field
+import Elemental.Form.Interaction as Interaction exposing (Interaction)
 import Elemental.View.Form.Field.Switch as Switch
 import Html.Styled as H
 
@@ -57,13 +58,17 @@ type alias Msg =
 
 type Msg_
     = ToggledSwitch Bool
+    | UserInteracted Interaction
 
 
-update : Msg_ -> Model -> ( Model, Cmd Msg_ )
+update : Msg_ -> Model -> ( Model, Cmd Msg_, Maybe Interaction )
 update msg model =
     case msg of
         ToggledSwitch newValue ->
-            ( { model | value = newValue }, Cmd.none )
+            ( { model | value = newValue }, Cmd.none, Nothing )
+
+        UserInteracted interaction ->
+            ( model, Cmd.none, Just interaction )
 
 
 
@@ -90,5 +95,7 @@ view options model =
         , disabled = options.disabled
         , size = options.size
         , onToggle = ToggledSwitch
+        , maybeOnInteraction =
+            Just <| Interaction.config UserInteracted options.userInteractions
         }
         model.value

--- a/src/Elemental/Form/Field/Switch.elm
+++ b/src/Elemental/Form/Field/Switch.elm
@@ -96,6 +96,6 @@ view options model =
         , size = options.size
         , onToggle = ToggledSwitch
         , maybeInteractionConfig =
-            Just <| Interaction.config UserInteracted options.userInteractions
+            Interaction.toConfig UserInteracted options.userInteractions
         }
         model.value

--- a/src/Elemental/Form/Field/Switch.elm
+++ b/src/Elemental/Form/Field/Switch.elm
@@ -8,7 +8,7 @@ module Elemental.Form.Field.Switch exposing
     )
 
 import Elemental.Form.Field as Field
-import Elemental.Form.Interaction as Interaction
+import Elemental.Form.Interaction as Interaction exposing (Interaction)
 import Elemental.View.Form.Field.Switch as Switch
 import Html.Styled as H
 

--- a/src/Elemental/Form/Field/Switch.elm
+++ b/src/Elemental/Form/Field/Switch.elm
@@ -95,7 +95,7 @@ view options model =
         , disabled = options.disabled
         , size = options.size
         , onToggle = ToggledSwitch
-        , maybeOnInteraction =
+        , maybeInteractionConfig =
             Just <| Interaction.config UserInteracted options.userInteractions
         }
         model.value

--- a/src/Elemental/Form/Field/Switch.elm
+++ b/src/Elemental/Form/Field/Switch.elm
@@ -8,7 +8,7 @@ module Elemental.Form.Field.Switch exposing
     )
 
 import Elemental.Form.Field as Field
-import Elemental.Form.Interaction as Interaction exposing (Interaction)
+import Elemental.Form.Interaction as Interaction
 import Elemental.View.Form.Field.Switch as Switch
 import Html.Styled as H
 

--- a/src/Elemental/Form/Interaction.elm
+++ b/src/Elemental/Form/Interaction.elm
@@ -1,0 +1,96 @@
+module Elemental.Form.Interaction exposing (Config, Interaction(..), config, onInteraction)
+
+import Html.Styled as H
+import Html.Styled.Events as HE
+import Json.Decode as JD
+
+
+type Interaction
+    = Click
+    | DoubleClick
+    | MouseEnter
+    | MouseLeave
+    | MouseOver
+    | MouseOut
+    | MouseDown
+    | MouseUp
+    | TouchStart
+    | TouchEnd
+    | TouchMove
+    | Focus
+    | Blur
+
+
+type Config msg
+    = Config
+        { toMsg : Interaction -> msg
+        , detectableInteractions : List Interaction
+        }
+
+
+config : (Interaction -> msg) -> List Interaction -> Config msg
+config toMsg detectableInteractions =
+    Config
+        { toMsg = toMsg
+        , detectableInteractions = detectableInteractions
+        }
+
+
+onInteraction : Maybe (Config msg) -> List (H.Attribute msg)
+onInteraction maybeConfig =
+    case maybeConfig of
+        Just (Config { toMsg, detectableInteractions }) ->
+            List.map (interactionToAttribute toMsg) detectableInteractions
+
+        Nothing ->
+            []
+
+
+interactionToAttribute : (Interaction -> msg) -> Interaction -> H.Attribute msg
+interactionToAttribute toMsg interaction =
+    let
+        on name =
+            JD.succeed >> HE.on name
+
+        msg =
+            toMsg interaction
+    in
+    case interaction of
+        Click ->
+            HE.onClick msg
+
+        DoubleClick ->
+            HE.onDoubleClick msg
+
+        MouseEnter ->
+            HE.onMouseEnter msg
+
+        MouseLeave ->
+            HE.onMouseLeave msg
+
+        MouseOver ->
+            HE.onMouseOver msg
+
+        MouseOut ->
+            HE.onMouseOut msg
+
+        MouseDown ->
+            HE.onMouseDown msg
+
+        MouseUp ->
+            HE.onMouseUp msg
+
+        TouchStart ->
+            on "touchstart" msg
+
+        TouchEnd ->
+            on "touchend" msg
+
+        TouchMove ->
+            on "touchmove" msg
+
+        Focus ->
+            HE.onFocus msg
+
+        Blur ->
+            HE.onBlur msg

--- a/src/Elemental/Form/Interaction.elm
+++ b/src/Elemental/Form/Interaction.elm
@@ -1,4 +1,9 @@
-module Elemental.Form.Interaction exposing (Config, Interaction(..), config, onInteraction)
+module Elemental.Form.Interaction exposing
+    ( Config
+    , Interaction(..)
+    , toAttrs
+    , toConfig
+    )
 
 import Html.Styled as H
 import Html.Styled.Events as HE
@@ -24,26 +29,26 @@ type Interaction
 type Config msg
     = Config
         { toMsg : Interaction -> msg
-        , detectableInteractions : List Interaction
+        , interactions : List Interaction
         }
 
 
-config : (Interaction -> msg) -> List Interaction -> Config msg
-config toMsg detectableInteractions =
-    Config
-        { toMsg = toMsg
-        , detectableInteractions = detectableInteractions
-        }
+toConfig : (Interaction -> msg) -> List Interaction -> Maybe (Config msg)
+toConfig toMsg interactions =
+    if List.isEmpty interactions then
+        Nothing
+
+    else
+        Just <|
+            Config
+                { toMsg = toMsg
+                , interactions = interactions
+                }
 
 
-onInteraction : Maybe (Config msg) -> List (H.Attribute msg)
-onInteraction maybeConfig =
-    case maybeConfig of
-        Just (Config { toMsg, detectableInteractions }) ->
-            List.map (interactionToAttribute toMsg) detectableInteractions
-
-        Nothing ->
-            []
+toAttrs : Config msg -> List (H.Attribute msg)
+toAttrs (Config { toMsg, interactions }) =
+    List.map (interactionToAttribute toMsg) interactions
 
 
 interactionToAttribute : (Interaction -> msg) -> Interaction -> H.Attribute msg

--- a/src/Elemental/View/Form/Field.elm
+++ b/src/Elemental/View/Form/Field.elm
@@ -88,7 +88,7 @@ viewNonEmptyLabel theme layout isRequired hasError maybeToErrorIcon text =
     let
         labelTypographyStyle =
             Typography.toStyle theme.typography.label
-                
+
         labelStyle =
             if hasError then
                 [ labelTypographyStyle, Css.color theme.colors.error ]
@@ -125,10 +125,11 @@ viewStar theme layout isRequired =
     else
         H.text ""
 
+
 viewErrorIcon : Theme -> L.Layout msg -> Bool -> Maybe (Css.Color -> H.Html msg) -> H.Html msg
 viewErrorIcon theme layout hasError maybeToErrorIcon =
-    case (maybeToErrorIcon, hasError) of
-        (Just toErrorIcon, True) ->
+    case ( maybeToErrorIcon, hasError ) of
+        ( Just toErrorIcon, True ) ->
             L.viewRow
                 L.Center
                 []

--- a/src/Elemental/View/Form/Field/Input.elm
+++ b/src/Elemental/View/Form/Field/Input.elm
@@ -10,7 +10,7 @@ module Elemental.View.Form.Field.Input exposing
 import Css
 import Elemental.Css as LibCss
 import Elemental.Css.BorderRadius as BorderRadius
-import Elemental.Form.Interaction as Interaction exposing (Interaction)
+import Elemental.Form.Interaction as Interaction
 import Elemental.Layout as L
 import Html.Styled as H
 import Html.Styled.Attributes as HA

--- a/src/Elemental/View/Form/Field/Input.elm
+++ b/src/Elemental/View/Form/Field/Input.elm
@@ -10,6 +10,7 @@ module Elemental.View.Form.Field.Input exposing
 import Css
 import Elemental.Css as LibCss
 import Elemental.Css.BorderRadius as BorderRadius
+import Elemental.Form.Interaction as Interaction exposing (Interaction)
 import Elemental.Layout as L
 import Html.Styled as H
 import Html.Styled.Attributes as HA
@@ -28,6 +29,7 @@ type alias Options msg =
     , placeholder : String
     , onInput : String -> msg
     , customAttrs : List (H.Attribute msg)
+    , maybeOnInteraction : Maybe (Interaction.Config msg)
     }
 
 
@@ -232,7 +234,8 @@ view options value =
                 []
 
             else
-                [ HE.onInput options.onInput ]
+                Interaction.onInteraction options.maybeOnInteraction
+                    ++ [ HE.onInput options.onInput ]
 
         attrs =
             options.customAttrs ++ baseAttrs ++ additionalAttrs

--- a/src/Elemental/View/Form/Field/Input.elm
+++ b/src/Elemental/View/Form/Field/Input.elm
@@ -234,7 +234,10 @@ view options value =
                 []
 
             else
-                Interaction.toAttr options.maybeInteractionConfig
+                (options.maybeInteractionConfig
+                    |> Maybe.map Interaction.toAttrs
+                    |> Maybe.withDefault []
+                )
                     ++ [ HE.onInput options.onInput ]
 
         attrs =

--- a/src/Elemental/View/Form/Field/Input.elm
+++ b/src/Elemental/View/Form/Field/Input.elm
@@ -29,7 +29,7 @@ type alias Options msg =
     , placeholder : String
     , onInput : String -> msg
     , customAttrs : List (H.Attribute msg)
-    , maybeOnInteraction : Maybe (Interaction.Config msg)
+    , maybeInteractionConfig : Maybe (Interaction.Config msg)
     }
 
 
@@ -234,7 +234,7 @@ view options value =
                 []
 
             else
-                Interaction.onInteraction options.maybeOnInteraction
+                Interaction.toAttr options.maybeInteractionConfig
                     ++ [ HE.onInput options.onInput ]
 
         attrs =

--- a/src/Elemental/View/Form/Field/Select.elm
+++ b/src/Elemental/View/Form/Field/Select.elm
@@ -10,6 +10,7 @@ import Css
 import Dict exposing (Dict)
 import Elemental.Css as LibCss
 import Elemental.Css.BorderRadius as BorderRadius
+import Elemental.Form.Interaction as Interaction exposing (Interaction)
 import Elemental.Layout as Layout exposing (Layout)
 import Html.Styled as Html exposing (Html)
 import Html.Styled.Attributes as Attrs
@@ -26,6 +27,7 @@ type alias Options value msg =
     , disabled : Bool
     , error : Bool
     , onInput : Maybe value -> msg
+    , maybeOnInteraction : Maybe (Interaction.Config msg)
     , viewCaret : Html msg
     , choices : List (Choice value)
     , customAttrs : List (Html.Attribute msg)
@@ -218,7 +220,8 @@ viewHtmlSelect options value choiceTextToValue =
                 []
 
             else
-                [ Events.onInput onInput ]
+                Interaction.onInteraction options.maybeOnInteraction
+                    ++ [ Events.onInput onInput ]
 
         attrs =
             options.customAttrs ++ baseAttrs ++ additionalAttrs

--- a/src/Elemental/View/Form/Field/Select.elm
+++ b/src/Elemental/View/Form/Field/Select.elm
@@ -27,7 +27,7 @@ type alias Options value msg =
     , disabled : Bool
     , error : Bool
     , onInput : Maybe value -> msg
-    , maybeOnInteraction : Maybe (Interaction.Config msg)
+    , maybeInteractionConfig : Maybe (Interaction.Config msg)
     , viewCaret : Html msg
     , choices : List (Choice value)
     , customAttrs : List (Html.Attribute msg)
@@ -220,7 +220,7 @@ viewHtmlSelect options value choiceTextToValue =
                 []
 
             else
-                Interaction.onInteraction options.maybeOnInteraction
+                Interaction.toAttr options.maybeInteractionConfig
                     ++ [ Events.onInput onInput ]
 
         attrs =

--- a/src/Elemental/View/Form/Field/Select.elm
+++ b/src/Elemental/View/Form/Field/Select.elm
@@ -220,7 +220,10 @@ viewHtmlSelect options value choiceTextToValue =
                 []
 
             else
-                Interaction.toAttr options.maybeInteractionConfig
+                (options.maybeInteractionConfig
+                    |> Maybe.map Interaction.toAttrs
+                    |> Maybe.withDefault []
+                )
                     ++ [ Events.onInput onInput ]
 
         attrs =

--- a/src/Elemental/View/Form/Field/Switch.elm
+++ b/src/Elemental/View/Form/Field/Switch.elm
@@ -179,7 +179,10 @@ viewInput options ( width, height ) isSelected =
                 ]
 
             else
-                Interaction.toAttr options.maybeInteractionConfig
+                (options.maybeInteractionConfig
+                    |> Maybe.map Interaction.toAttrs
+                    |> Maybe.withDefault []
+                )
                     ++ [ Events.onCheck options.onToggle
                        , HA.css
                             [ Css.cursor Css.pointer
@@ -307,7 +310,10 @@ viewNonEmptyLabel options currentValue =
                 []
 
             else
-                Interaction.toAttr options.maybeInteractionConfig
+                (options.maybeInteractionConfig
+                    |> Maybe.map Interaction.toAttrs
+                    |> Maybe.withDefault []
+                )
                     ++ [ Events.onClick <|
                             options.onToggle (not currentValue)
                        ]

--- a/src/Elemental/View/Form/Field/Switch.elm
+++ b/src/Elemental/View/Form/Field/Switch.elm
@@ -8,6 +8,7 @@ module Elemental.View.Form.Field.Switch exposing
 import Css
 import Css.Transitions
 import Elemental.Css as LibCss
+import Elemental.Form.Interaction as Interaction exposing (Interaction)
 import Elemental.Layout as L
 import Elemental.Typography as Typography exposing (Typography)
 import Html.Styled as H
@@ -22,6 +23,7 @@ type alias Options msg =
     , disabled : Bool
     , size : Size
     , onToggle : Bool -> msg
+    , maybeOnInteraction : Maybe (Interaction.Config msg)
     }
 
 
@@ -177,11 +179,12 @@ viewInput options ( width, height ) isSelected =
                 ]
 
             else
-                [ Events.onCheck options.onToggle
-                , HA.css
-                    [ Css.cursor Css.pointer
-                    ]
-                ]
+                Interaction.onInteraction options.maybeOnInteraction
+                    ++ [ Events.onCheck options.onToggle
+                       , HA.css
+                            [ Css.cursor Css.pointer
+                            ]
+                       ]
 
         attrs =
             baseAttrs ++ additionalAttrs
@@ -304,9 +307,10 @@ viewNonEmptyLabel options currentValue =
                 []
 
             else
-                [ Events.onClick <|
-                    options.onToggle (not currentValue)
-                ]
+                Interaction.onInteraction options.maybeOnInteraction
+                    ++ [ Events.onClick <|
+                            options.onToggle (not currentValue)
+                       ]
     in
     H.div interactionAttr
         [ L.viewRow

--- a/src/Elemental/View/Form/Field/Switch.elm
+++ b/src/Elemental/View/Form/Field/Switch.elm
@@ -23,7 +23,7 @@ type alias Options msg =
     , disabled : Bool
     , size : Size
     , onToggle : Bool -> msg
-    , maybeOnInteraction : Maybe (Interaction.Config msg)
+    , maybeInteractionConfig : Maybe (Interaction.Config msg)
     }
 
 
@@ -179,7 +179,7 @@ viewInput options ( width, height ) isSelected =
                 ]
 
             else
-                Interaction.onInteraction options.maybeOnInteraction
+                Interaction.toAttr options.maybeInteractionConfig
                     ++ [ Events.onCheck options.onToggle
                        , HA.css
                             [ Css.cursor Css.pointer
@@ -307,7 +307,7 @@ viewNonEmptyLabel options currentValue =
                 []
 
             else
-                Interaction.onInteraction options.maybeOnInteraction
+                Interaction.toAttr options.maybeInteractionConfig
                     ++ [ Events.onClick <|
                             options.onToggle (not currentValue)
                        ]

--- a/src/Elemental/View/Form/Field/Textarea.elm
+++ b/src/Elemental/View/Form/Field/Textarea.elm
@@ -132,7 +132,7 @@ view options value =
                 []
 
             else
-                Interaction.onInteraction options.maybeConfig
+                Interaction.onInteraction options.maybeInteractionConfig
                     ++ [ HE.onInput options.onInput ]
 
         attrs =

--- a/src/Elemental/View/Form/Field/Textarea.elm
+++ b/src/Elemental/View/Form/Field/Textarea.elm
@@ -3,7 +3,7 @@ module Elemental.View.Form.Field.Textarea exposing (Options, Theme, view)
 import Css
 import Elemental.Css as LibCss
 import Elemental.Css.BorderRadius as BorderRadius
-import Elemental.Form.Interaction as Interaction exposing (Interaction)
+import Elemental.Form.Interaction as Interaction
 import Elemental.Layout as L
 import Html.Styled as H
 import Html.Styled.Attributes as HA
@@ -18,7 +18,7 @@ type alias Options msg =
     , placeholder : String
     , height : Float
     , onInput : String -> msg
-    , maybeConfig : Maybe (Interaction.Config msg)
+    , maybeInteractionConfig : Maybe (Interaction.Config msg)
     }
 
 

--- a/src/Elemental/View/Form/Field/Textarea.elm
+++ b/src/Elemental/View/Form/Field/Textarea.elm
@@ -3,6 +3,7 @@ module Elemental.View.Form.Field.Textarea exposing (Options, Theme, view)
 import Css
 import Elemental.Css as LibCss
 import Elemental.Css.BorderRadius as BorderRadius
+import Elemental.Form.Interaction as Interaction exposing (Interaction)
 import Elemental.Layout as L
 import Html.Styled as H
 import Html.Styled.Attributes as HA
@@ -17,6 +18,7 @@ type alias Options msg =
     , placeholder : String
     , height : Float
     , onInput : String -> msg
+    , maybeConfig : Maybe (Interaction.Config msg)
     }
 
 
@@ -130,7 +132,8 @@ view options value =
                 []
 
             else
-                [ HE.onInput options.onInput ]
+                Interaction.onInteraction options.maybeConfig
+                    ++ [ HE.onInput options.onInput ]
 
         attrs =
             baseAttrs ++ additionalAttrs

--- a/src/Elemental/View/Form/Field/Textarea.elm
+++ b/src/Elemental/View/Form/Field/Textarea.elm
@@ -132,7 +132,10 @@ view options value =
                 []
 
             else
-                Interaction.toAttr options.maybeInteractionConfig
+                (options.maybeInteractionConfig
+                    |> Maybe.map Interaction.toAttrs
+                    |> Maybe.withDefault []
+                )
                     ++ [ HE.onInput options.onInput ]
 
         attrs =

--- a/src/Elemental/View/Form/Field/Textarea.elm
+++ b/src/Elemental/View/Form/Field/Textarea.elm
@@ -132,7 +132,7 @@ view options value =
                 []
 
             else
-                Interaction.onInteraction options.maybeInteractionConfig
+                Interaction.toAttr options.maybeInteractionConfig
                     ++ [ HE.onInput options.onInput ]
 
         attrs =


### PR DESCRIPTION
### Usage

#### Interactions on `Field`s

Let's imagine we wanted to keep track of the field currently in focus for a form/page we would:

1.  Listen to Focus and Blur events from your `App.Form.Field.ShortText`

```elm
-- ShortText.elm

toOptions : { ... } -> ShortText.Options
toOptions options =
    let
       ...
    in
    { fieldTheme =
        ....
    , userInteractions =
        [ Interaction.Focus
        , Interaction.Blur
        ]
    }
```

2. React to interaction events from the form/page containing the field:

```elm
-- LoginForm.elm

...

update : Msg -> Model -> ( Model, Cmd Msg )
update msg model =
    case msg of
        NoOp ->
            ( model
            , Cmd.none
            )

        GotPasswordFieldMsg msg_ ->
            let
                ( passwordFieldModel, passwordFieldMsg, maybeInteraction ) =
                    ShortTextField.field.update msg_ model.passwordFieldModel

                currentField = 
                    case (maybeInteraction, model.currentField) of
                        -- We are on the password field and it blurred
                        (Just Interaction.Blur, Just PasswordField ) ->
                            Nothing

                        -- We have focus on the password field
                        (Just Interaction.Focus, _ ) ->
                            Just PasswordField 

                        _ ->
                           model.currentField

            in
            ( { model | passwordFieldModel = passwordFieldModel, currentField = currentField }
            , Cmd.map GotPasswordFieldMsg passwordFieldMsg
            )

```

#### Interactions on `View`s

`Elemental.View.Form.Field.*` views now receive a `maybeInteractionConfig` they can use to subscribe to interactions. The `Interaction.config` function expects a function that generates a message when the interaction is detected and a list of interactions to detect.

1. Listen to Focus and Blur events from your App.View.Form.Field.Input

```elm
toOptions :
    { ...
    , onInput : String -> msg
    , onInteraction : Interaction.Interaction -> msg
    }
    -> Input.Options msg
toOptions options =
    { ...
    , maybeOnInteraction =
        Interaction.config options.onInteraction [ Interaction.Focus , Interaction.Blur ]
    }
```

2. React to interaction events from the form/page containing the field:

```elm
-- LoginForm.elm

...

update : Msg -> Model -> ( Model, Cmd Msg )
update msg model =
    case msg of
        ...

        InteractedWithPasswordField interaction  ->
            let
                currentField = 
                    case ( interaction , model.currentField ) of
                        -- We are on the password field and it blurred
                        ( Interaction.Blur, Just PasswordField ) ->
                            Nothing

                        -- We have focus on the password field
                        ( Interaction.Focus, _ ) ->
                            Just PasswordField 

                        _ ->
                           model.currentField

            in
            ( { model | currentField = currentField }
            , Cmd.none
            )

view model =
    Input.view 
        ( Input.toOptions { ..., onInteraction = InteractedWithPasswordField } )
        model.password

```

