### PR TITLE
Improve interaction implementation

### DIFF
--- a/src/Elemental/Form/Field.elm
+++ b/src/Elemental/Form/Field.elm
@@ -157,8 +157,7 @@ update validate updateField msg model =
     case msg of
         FieldChanged fieldMsg ->
             updateField fieldMsg model
-                |> Tuple.mapFirst validate
-                |> Tuple.mapSecond (Cmd.map FieldChanged)
+                |> Tuple.mapBoth validate (Cmd.map FieldChanged)
 
 
 view : (Options fieldMsg msg options -> Model model value -> H.Html msg) -> Options fieldMsg msg options -> Model model value -> H.Html msg

--- a/src/Elemental/Form/Field/LongText.elm
+++ b/src/Elemental/Form/Field/LongText.elm
@@ -13,11 +13,11 @@ import Elemental.View.Form.Field.Textarea as Textarea
 import Html.Styled as H
 
 
-type alias Field =
-    Field.Field {} {} Msg_ Options_ String
+type alias Field msg =
+    Field.Field {} {} Msg_ msg Options_ String
 
 
-field : Field
+field : Field msg
 field =
     Field.build
         { init = init
@@ -58,25 +58,21 @@ type alias Msg =
 
 type Msg_
     = ChangedInput String
-    | UserInteracted Interaction
 
 
-update : Msg_ -> Model -> ( Model, Cmd Msg_, Maybe Interaction )
+update : Msg_ -> Model -> ( Model, Cmd Msg_ )
 update msg model =
     case msg of
         ChangedInput newValue ->
-            ( { model | value = newValue }, Cmd.none, Nothing )
-
-        UserInteracted interaction ->
-            ( model, Cmd.none, Just interaction )
+            ( { model | value = newValue }, Cmd.none )
 
 
 
 -- VIEW
 
 
-type alias Options =
-    Field.Options Msg_ Options_
+type alias Options msg =
+    Field.Options Msg_ msg Options_
 
 
 type alias Options_ =
@@ -86,7 +82,7 @@ type alias Options_ =
     }
 
 
-view : Options -> Model -> H.Html Msg_
+view : Options msg -> Model -> H.Html msg
 view options model =
     let
         fieldColors =
@@ -108,8 +104,7 @@ view options model =
         , error = Field.hasError model
         , placeholder = options.placeholder
         , height = options.height
-        , onInput = ChangedInput
-        , maybeInteractionConfig =
-            Interaction.toConfig UserInteracted options.userInteractions
+        , onInput = ChangedInput >> Field.toFieldMsg >> options.onChange
+        , interaction = options.interaction
         }
         model.value

--- a/src/Elemental/Form/Field/ShortText.elm
+++ b/src/Elemental/Form/Field/ShortText.elm
@@ -14,11 +14,11 @@ import Elemental.View.Form.Field.Input as Input
 import Html.Styled as H
 
 
-type alias Field =
-    Field.Field {} {} Msg_ Options_ String
+type alias Field msg =
+    Field.Field {} {} Msg_ msg (Options_ msg) String
 
 
-field : Field
+field : Field msg
 field =
     Field.build
         { init = init
@@ -59,43 +59,39 @@ type alias Msg =
 
 type Msg_
     = ChangedInput String
-    | UserInteracted Interaction
 
 
-update : Msg_ -> Model -> ( Model, Cmd Msg_, Maybe Interaction )
+update : Msg_ -> Model -> ( Model, Cmd Msg_ )
 update msg model =
     case msg of
         ChangedInput newValue ->
-            ( { model | value = newValue }, Cmd.none, Nothing )
-
-        UserInteracted interaction ->
-            ( model, Cmd.none, Just interaction )
+            ( { model | value = newValue }, Cmd.none )
 
 
 
 -- VIEW
 
 
-type alias Options =
-    Field.Options Msg_ Options_
+type alias Options msg =
+    Field.Options Msg_ msg (Options_ msg)
 
 
-type alias Icon =
-    Input.Icon Msg_
+type alias Icon msg =
+    Input.Icon msg
 
 
-type alias Options_ =
+type alias Options_ msg =
     { widgetTheme : Input.Theme
     , type_ : Input.Type
     , size : Input.Size
-    , icon : Maybe Icon
+    , icon : Maybe (Icon msg)
     , placeholder : String
     , autofocus : Bool
-    , customAttrs : List (H.Attribute Msg_)
+    , customAttrs : List (H.Attribute msg)
     }
 
 
-view : Options -> Model -> H.Html Msg_
+view : Options msg -> Model -> H.Html msg
 view options model =
     let
         fieldColors =
@@ -120,9 +116,8 @@ view options model =
         , disabled = options.disabled
         , error = Field.hasError model
         , placeholder = options.placeholder
-        , onInput = ChangedInput
-        , maybeInteractionConfig =
-            Interaction.toConfig UserInteracted options.userInteractions
+        , onInput = ChangedInput >> Field.toFieldMsg >> options.onChange
+        , interaction = options.interaction
         , customAttrs = options.customAttrs
         }
         model.value

--- a/src/Elemental/Form/Field/Switch.elm
+++ b/src/Elemental/Form/Field/Switch.elm
@@ -13,11 +13,11 @@ import Elemental.View.Form.Field.Switch as Switch
 import Html.Styled as H
 
 
-type alias Field =
-    Field.Field {} {} Msg_ Options_ Bool
+type alias Field msg =
+    Field.Field {} {} Msg_ msg Options_ Bool
 
 
-field : Field
+field : Field msg
 field =
     Field.build
         { init = init
@@ -58,25 +58,21 @@ type alias Msg =
 
 type Msg_
     = ToggledSwitch Bool
-    | UserInteracted Interaction
 
 
-update : Msg_ -> Model -> ( Model, Cmd Msg_, Maybe Interaction )
+update : Msg_ -> Model -> ( Model, Cmd Msg_ )
 update msg model =
     case msg of
         ToggledSwitch newValue ->
-            ( { model | value = newValue }, Cmd.none, Nothing )
-
-        UserInteracted interaction ->
-            ( model, Cmd.none, Just interaction )
+            ( { model | value = newValue }, Cmd.none )
 
 
 
 -- VIEW
 
 
-type alias Options =
-    Field.Options Msg_ Options_
+type alias Options msg =
+    Field.Options Msg_ msg Options_
 
 
 type alias Options_ =
@@ -86,7 +82,7 @@ type alias Options_ =
     }
 
 
-view : Options -> Model -> H.Html Msg_
+view : Options msg -> Model -> H.Html msg
 view options model =
     Switch.view
         { theme = options.widgetTheme
@@ -94,8 +90,7 @@ view options model =
         , text = options.switchText
         , disabled = options.disabled
         , size = options.size
-        , onToggle = ToggledSwitch
-        , maybeInteractionConfig =
-            Interaction.toConfig UserInteracted options.userInteractions
+        , onToggle = ToggledSwitch >> Field.toFieldMsg >> options.onChange
+        , interaction = options.interaction
         }
         model.value

--- a/src/Elemental/Form/Interaction.elm
+++ b/src/Elemental/Form/Interaction.elm
@@ -24,160 +24,147 @@ import Json.Decode as JD
 
 
 type Interaction msg
-    = Interaction (Config msg)
+    = Interaction (List (Action msg) -> List (Action msg))
 
 
-type alias Config msg =
-    { onClick : Maybe msg
-    , onDoubleClick : Maybe msg
-    , onMouseEnter : Maybe msg
-    , onMouseLeave : Maybe msg
-    , onMouseOver : Maybe msg
-    , onMouseOut : Maybe msg
-    , onMouseDown : Maybe msg
-    , onMouseUp : Maybe msg
-    , onTouchStart : Maybe msg
-    , onTouchEnd : Maybe msg
-    , onTouchMove : Maybe msg
-    , onFocus : Maybe msg
-    , onBlur : Maybe msg
-    }
-
-
-noneConfig : Config msg
-noneConfig =
-    { onClick = Nothing
-    , onDoubleClick = Nothing
-    , onMouseEnter = Nothing
-    , onMouseLeave = Nothing
-    , onMouseOver = Nothing
-    , onMouseOut = Nothing
-    , onMouseDown = Nothing
-    , onMouseUp = Nothing
-    , onTouchStart = Nothing
-    , onTouchEnd = Nothing
-    , onTouchMove = Nothing
-    , onFocus = Nothing
-    , onBlur = Nothing
-    }
+type Action msg
+    = Click msg
+    | DoubleClick msg
+    | MouseEnter msg
+    | MouseLeave msg
+    | MouseOver msg
+    | MouseOut msg
+    | MouseDown msg
+    | MouseUp msg
+    | TouchStart msg
+    | TouchEnd msg
+    | TouchMove msg
+    | Focus msg
+    | Blur msg
 
 
 none : Interaction msg
 none =
-    Interaction noneConfig
+    Interaction identity
 
 
 onClick : msg -> Interaction msg
-onClick msg =
-    Interaction { noneConfig | onClick = Just msg }
+onClick =
+    Interaction << (::) << Click
 
 
 onDoubleClick : msg -> Interaction msg
-onDoubleClick msg =
-    Interaction { noneConfig | onDoubleClick = Just msg }
+onDoubleClick =
+    Interaction << (::) << DoubleClick
 
 
 onMouseEnter : msg -> Interaction msg
-onMouseEnter msg =
-    Interaction { noneConfig | onMouseEnter = Just msg }
+onMouseEnter =
+    Interaction << (::) << MouseEnter
 
 
 onMouseLeave : msg -> Interaction msg
-onMouseLeave msg =
-    Interaction { noneConfig | onMouseLeave = Just msg }
+onMouseLeave =
+    Interaction << (::) << MouseLeave
 
 
 onMouseOver : msg -> Interaction msg
-onMouseOver msg =
-    Interaction { noneConfig | onMouseOver = Just msg }
+onMouseOver =
+    Interaction << (::) << MouseOver
 
 
 onMouseOut : msg -> Interaction msg
-onMouseOut msg =
-    Interaction { noneConfig | onMouseOut = Just msg }
+onMouseOut =
+    Interaction << (::) << MouseOut
 
 
 onMouseDown : msg -> Interaction msg
-onMouseDown msg =
-    Interaction { noneConfig | onMouseDown = Just msg }
+onMouseDown =
+    Interaction << (::) << MouseDown
 
 
 onMouseUp : msg -> Interaction msg
-onMouseUp msg =
-    Interaction { noneConfig | onMouseUp = Just msg }
+onMouseUp =
+    Interaction << (::) << MouseUp
 
 
 onTouchStart : msg -> Interaction msg
-onTouchStart msg =
-    Interaction { noneConfig | onTouchStart = Just msg }
+onTouchStart =
+    Interaction << (::) << TouchStart
 
 
 onTouchEnd : msg -> Interaction msg
-onTouchEnd msg =
-    Interaction { noneConfig | onTouchEnd = Just msg }
+onTouchEnd =
+    Interaction << (::) << TouchEnd
 
 
 onTouchMove : msg -> Interaction msg
-onTouchMove msg =
-    Interaction { noneConfig | onTouchMove = Just msg }
+onTouchMove =
+    Interaction << (::) << TouchMove
 
 
 onFocus : msg -> Interaction msg
-onFocus msg =
-    Interaction { noneConfig | onFocus = Just msg }
+onFocus =
+    Interaction << (::) << Focus
 
 
 onBlur : msg -> Interaction msg
-onBlur msg =
-    Interaction { noneConfig | onBlur = Just msg }
+onBlur =
+    Interaction << (::) << Blur
 
 
 and : Interaction msg -> Interaction msg -> Interaction msg
-and (Interaction interaction2) (Interaction interaction1) =
-    let
-        overrideIfSet fn =
-            case fn interaction2 of
-                Just i ->
-                    Just i
-
-                Nothing ->
-                    fn interaction1
-    in
-    Interaction
-        { onClick = overrideIfSet .onClick
-        , onDoubleClick = overrideIfSet .onDoubleClick
-        , onMouseEnter = overrideIfSet .onMouseEnter
-        , onMouseLeave = overrideIfSet .onMouseLeave
-        , onMouseOver = overrideIfSet .onMouseOver
-        , onMouseOut = overrideIfSet .onMouseOut
-        , onMouseDown = overrideIfSet .onMouseDown
-        , onMouseUp = overrideIfSet .onMouseUp
-        , onTouchStart = overrideIfSet .onTouchStart
-        , onTouchEnd = overrideIfSet .onTouchEnd
-        , onTouchMove = overrideIfSet .onTouchMove
-        , onFocus = overrideIfSet .onFocus
-        , onBlur = overrideIfSet .onBlur
-        }
+and (Interaction b) (Interaction a) =
+    Interaction (a >> b)
 
 
 toAttrs : Interaction msg -> List (H.Attribute msg)
-toAttrs (Interaction interaction) =
+toAttrs (Interaction toActions) =
+    List.reverse <| List.map toEvent (toActions [])
+
+
+toEvent : Action msg -> H.Attribute msg
+toEvent action =
     let
         on name =
             JD.succeed >> HE.on name
     in
-    [ Maybe.map HE.onClick interaction.onClick
-    , Maybe.map HE.onDoubleClick interaction.onDoubleClick
-    , Maybe.map HE.onMouseEnter interaction.onMouseEnter
-    , Maybe.map HE.onMouseLeave interaction.onMouseLeave
-    , Maybe.map HE.onMouseOver interaction.onMouseOver
-    , Maybe.map HE.onMouseOut interaction.onMouseOut
-    , Maybe.map HE.onMouseDown interaction.onMouseDown
-    , Maybe.map HE.onMouseUp interaction.onMouseUp
-    , Maybe.map (on "touchstart") interaction.onTouchStart
-    , Maybe.map (on "touchend") interaction.onTouchEnd
-    , Maybe.map (on "touchmove") interaction.onTouchMove
-    , Maybe.map HE.onFocus interaction.onFocus
-    , Maybe.map HE.onBlur interaction.onBlur
-    ]
-        |> List.filterMap identity
+    case action of
+        Click msg ->
+            HE.onClick msg
+
+        DoubleClick msg ->
+            HE.onDoubleClick msg
+
+        MouseEnter msg ->
+            HE.onMouseEnter msg
+
+        MouseLeave msg ->
+            HE.onMouseLeave msg
+
+        MouseOver msg ->
+            HE.onMouseOver msg
+
+        MouseOut msg ->
+            HE.onMouseOut msg
+
+        MouseDown msg ->
+            HE.onMouseDown msg
+
+        MouseUp msg ->
+            HE.onMouseUp msg
+
+        TouchStart msg ->
+            on "touchstart" msg
+
+        TouchEnd msg ->
+            on "touchend" msg
+
+        TouchMove msg ->
+            on "touchmove" msg
+
+        Focus msg ->
+            HE.onFocus msg
+
+        Blur msg ->
+            HE.onBlur msg

--- a/src/Elemental/Form/Interaction.elm
+++ b/src/Elemental/Form/Interaction.elm
@@ -1,8 +1,21 @@
 module Elemental.Form.Interaction exposing
-    ( Config
-    , Interaction(..)
+    ( Interaction
+    , and
+    , none
+    , onBlur
+    , onClick
+    , onDoubleClick
+    , onFocus
+    , onMouseDown
+    , onMouseEnter
+    , onMouseLeave
+    , onMouseOut
+    , onMouseOver
+    , onMouseUp
+    , onTouchEnd
+    , onTouchMove
+    , onTouchStart
     , toAttrs
-    , toConfig
     )
 
 import Html.Styled as H
@@ -10,92 +23,161 @@ import Html.Styled.Events as HE
 import Json.Decode as JD
 
 
-type Interaction
-    = Click
-    | DoubleClick
-    | MouseEnter
-    | MouseLeave
-    | MouseOver
-    | MouseOut
-    | MouseDown
-    | MouseUp
-    | TouchStart
-    | TouchEnd
-    | TouchMove
-    | Focus
-    | Blur
+type Interaction msg
+    = Interaction (Config msg)
 
 
-type Config msg
-    = Config
-        { toMsg : Interaction -> msg
-        , interactions : List Interaction
+type alias Config msg =
+    { onClick : Maybe msg
+    , onDoubleClick : Maybe msg
+    , onMouseEnter : Maybe msg
+    , onMouseLeave : Maybe msg
+    , onMouseOver : Maybe msg
+    , onMouseOut : Maybe msg
+    , onMouseDown : Maybe msg
+    , onMouseUp : Maybe msg
+    , onTouchStart : Maybe msg
+    , onTouchEnd : Maybe msg
+    , onTouchMove : Maybe msg
+    , onFocus : Maybe msg
+    , onBlur : Maybe msg
+    }
+
+
+noneConfig : Config msg
+noneConfig =
+    { onClick = Nothing
+    , onDoubleClick = Nothing
+    , onMouseEnter = Nothing
+    , onMouseLeave = Nothing
+    , onMouseOver = Nothing
+    , onMouseOut = Nothing
+    , onMouseDown = Nothing
+    , onMouseUp = Nothing
+    , onTouchStart = Nothing
+    , onTouchEnd = Nothing
+    , onTouchMove = Nothing
+    , onFocus = Nothing
+    , onBlur = Nothing
+    }
+
+
+none : Interaction msg
+none =
+    Interaction noneConfig
+
+
+onClick : msg -> Interaction msg
+onClick msg =
+    Interaction { noneConfig | onClick = Just msg }
+
+
+onDoubleClick : msg -> Interaction msg
+onDoubleClick msg =
+    Interaction { noneConfig | onDoubleClick = Just msg }
+
+
+onMouseEnter : msg -> Interaction msg
+onMouseEnter msg =
+    Interaction { noneConfig | onMouseEnter = Just msg }
+
+
+onMouseLeave : msg -> Interaction msg
+onMouseLeave msg =
+    Interaction { noneConfig | onMouseLeave = Just msg }
+
+
+onMouseOver : msg -> Interaction msg
+onMouseOver msg =
+    Interaction { noneConfig | onMouseOver = Just msg }
+
+
+onMouseOut : msg -> Interaction msg
+onMouseOut msg =
+    Interaction { noneConfig | onMouseOut = Just msg }
+
+
+onMouseDown : msg -> Interaction msg
+onMouseDown msg =
+    Interaction { noneConfig | onMouseDown = Just msg }
+
+
+onMouseUp : msg -> Interaction msg
+onMouseUp msg =
+    Interaction { noneConfig | onMouseUp = Just msg }
+
+
+onTouchStart : msg -> Interaction msg
+onTouchStart msg =
+    Interaction { noneConfig | onTouchStart = Just msg }
+
+
+onTouchEnd : msg -> Interaction msg
+onTouchEnd msg =
+    Interaction { noneConfig | onTouchEnd = Just msg }
+
+
+onTouchMove : msg -> Interaction msg
+onTouchMove msg =
+    Interaction { noneConfig | onTouchMove = Just msg }
+
+
+onFocus : msg -> Interaction msg
+onFocus msg =
+    Interaction { noneConfig | onFocus = Just msg }
+
+
+onBlur : msg -> Interaction msg
+onBlur msg =
+    Interaction { noneConfig | onBlur = Just msg }
+
+
+and : Interaction msg -> Interaction msg -> Interaction msg
+and (Interaction interaction2) (Interaction interaction1) =
+    let
+        overrideIfSet fn =
+            case fn interaction2 of
+                Just i ->
+                    Just i
+
+                Nothing ->
+                    fn interaction1
+    in
+    Interaction
+        { onClick = overrideIfSet .onClick
+        , onDoubleClick = overrideIfSet .onDoubleClick
+        , onMouseEnter = overrideIfSet .onMouseEnter
+        , onMouseLeave = overrideIfSet .onMouseLeave
+        , onMouseOver = overrideIfSet .onMouseOver
+        , onMouseOut = overrideIfSet .onMouseOut
+        , onMouseDown = overrideIfSet .onMouseDown
+        , onMouseUp = overrideIfSet .onMouseUp
+        , onTouchStart = overrideIfSet .onTouchStart
+        , onTouchEnd = overrideIfSet .onTouchEnd
+        , onTouchMove = overrideIfSet .onTouchMove
+        , onFocus = overrideIfSet .onFocus
+        , onBlur = overrideIfSet .onBlur
         }
 
 
-toConfig : (Interaction -> msg) -> List Interaction -> Maybe (Config msg)
-toConfig toMsg interactions =
-    if List.isEmpty interactions then
-        Nothing
-
-    else
-        Just <|
-            Config
-                { toMsg = toMsg
-                , interactions = interactions
-                }
-
-
-toAttrs : Config msg -> List (H.Attribute msg)
-toAttrs (Config { toMsg, interactions }) =
-    List.map (interactionToAttribute toMsg) interactions
-
-
-interactionToAttribute : (Interaction -> msg) -> Interaction -> H.Attribute msg
-interactionToAttribute toMsg interaction =
+toAttrs : Interaction msg -> List (H.Attribute msg)
+toAttrs (Interaction interaction) =
     let
         on name =
             JD.succeed >> HE.on name
-
-        msg =
-            toMsg interaction
     in
-    case interaction of
-        Click ->
-            HE.onClick msg
-
-        DoubleClick ->
-            HE.onDoubleClick msg
-
-        MouseEnter ->
-            HE.onMouseEnter msg
-
-        MouseLeave ->
-            HE.onMouseLeave msg
-
-        MouseOver ->
-            HE.onMouseOver msg
-
-        MouseOut ->
-            HE.onMouseOut msg
-
-        MouseDown ->
-            HE.onMouseDown msg
-
-        MouseUp ->
-            HE.onMouseUp msg
-
-        TouchStart ->
-            on "touchstart" msg
-
-        TouchEnd ->
-            on "touchend" msg
-
-        TouchMove ->
-            on "touchmove" msg
-
-        Focus ->
-            HE.onFocus msg
-
-        Blur ->
-            HE.onBlur msg
+    [ Maybe.map HE.onClick interaction.onClick
+    , Maybe.map HE.onDoubleClick interaction.onDoubleClick
+    , Maybe.map HE.onMouseEnter interaction.onMouseEnter
+    , Maybe.map HE.onMouseLeave interaction.onMouseLeave
+    , Maybe.map HE.onMouseOver interaction.onMouseOver
+    , Maybe.map HE.onMouseOut interaction.onMouseOut
+    , Maybe.map HE.onMouseDown interaction.onMouseDown
+    , Maybe.map HE.onMouseUp interaction.onMouseUp
+    , Maybe.map (on "touchstart") interaction.onTouchStart
+    , Maybe.map (on "touchend") interaction.onTouchEnd
+    , Maybe.map (on "touchmove") interaction.onTouchMove
+    , Maybe.map HE.onFocus interaction.onFocus
+    , Maybe.map HE.onBlur interaction.onBlur
+    ]
+        |> List.filterMap identity

--- a/src/Elemental/View/Form/Field/Input.elm
+++ b/src/Elemental/View/Form/Field/Input.elm
@@ -10,7 +10,7 @@ module Elemental.View.Form.Field.Input exposing
 import Css
 import Elemental.Css as LibCss
 import Elemental.Css.BorderRadius as BorderRadius
-import Elemental.Form.Interaction as Interaction
+import Elemental.Form.Interaction as Interaction exposing (Interaction)
 import Elemental.Layout as L
 import Html.Styled as H
 import Html.Styled.Attributes as HA
@@ -29,7 +29,7 @@ type alias Options msg =
     , placeholder : String
     , onInput : String -> msg
     , customAttrs : List (H.Attribute msg)
-    , maybeInteractionConfig : Maybe (Interaction.Config msg)
+    , interaction : Interaction msg
     }
 
 
@@ -234,10 +234,7 @@ view options value =
                 []
 
             else
-                (options.maybeInteractionConfig
-                    |> Maybe.map Interaction.toAttrs
-                    |> Maybe.withDefault []
-                )
+                Interaction.toAttrs options.interaction
                     ++ [ HE.onInput options.onInput ]
 
         attrs =

--- a/src/Elemental/View/Form/Field/Select.elm
+++ b/src/Elemental/View/Form/Field/Select.elm
@@ -27,7 +27,7 @@ type alias Options value msg =
     , disabled : Bool
     , error : Bool
     , onInput : Maybe value -> msg
-    , maybeInteractionConfig : Maybe (Interaction.Config msg)
+    , interaction : Interaction msg
     , viewCaret : Html msg
     , choices : List (Choice value)
     , customAttrs : List (Html.Attribute msg)
@@ -220,10 +220,7 @@ viewHtmlSelect options value choiceTextToValue =
                 []
 
             else
-                (options.maybeInteractionConfig
-                    |> Maybe.map Interaction.toAttrs
-                    |> Maybe.withDefault []
-                )
+                Interaction.toAttrs options.interaction
                     ++ [ Events.onInput onInput ]
 
         attrs =

--- a/src/Elemental/View/Form/Field/Switch.elm
+++ b/src/Elemental/View/Form/Field/Switch.elm
@@ -23,7 +23,7 @@ type alias Options msg =
     , disabled : Bool
     , size : Size
     , onToggle : Bool -> msg
-    , maybeInteractionConfig : Maybe (Interaction.Config msg)
+    , interaction : Interaction msg
     }
 
 
@@ -179,10 +179,7 @@ viewInput options ( width, height ) isSelected =
                 ]
 
             else
-                (options.maybeInteractionConfig
-                    |> Maybe.map Interaction.toAttrs
-                    |> Maybe.withDefault []
-                )
+                Interaction.toAttrs options.interaction
                     ++ [ Events.onCheck options.onToggle
                        , HA.css
                             [ Css.cursor Css.pointer
@@ -310,10 +307,7 @@ viewNonEmptyLabel options currentValue =
                 []
 
             else
-                (options.maybeInteractionConfig
-                    |> Maybe.map Interaction.toAttrs
-                    |> Maybe.withDefault []
-                )
+                Interaction.toAttrs options.interaction
                     ++ [ Events.onClick <|
                             options.onToggle (not currentValue)
                        ]

--- a/src/Elemental/View/Form/Field/Textarea.elm
+++ b/src/Elemental/View/Form/Field/Textarea.elm
@@ -3,7 +3,7 @@ module Elemental.View.Form.Field.Textarea exposing (Options, Theme, view)
 import Css
 import Elemental.Css as LibCss
 import Elemental.Css.BorderRadius as BorderRadius
-import Elemental.Form.Interaction as Interaction
+import Elemental.Form.Interaction as Interaction exposing (Interaction)
 import Elemental.Layout as L
 import Html.Styled as H
 import Html.Styled.Attributes as HA
@@ -18,7 +18,7 @@ type alias Options msg =
     , placeholder : String
     , height : Float
     , onInput : String -> msg
-    , maybeInteractionConfig : Maybe (Interaction.Config msg)
+    , interaction : Interaction msg
     }
 
 
@@ -132,10 +132,7 @@ view options value =
                 []
 
             else
-                (options.maybeInteractionConfig
-                    |> Maybe.map Interaction.toAttrs
-                    |> Maybe.withDefault []
-                )
+                Interaction.toAttrs options.interaction
                     ++ [ HE.onInput options.onInput ]
 
         attrs =


### PR DESCRIPTION
It turns out that @dhruvio's suggestion in #15 provides a much better API than what I had come up with. In practice, it is not enjoyable to deal with the `maybeInteraction` produced when an interaction happens.

I was able to implement the suggested API by focusing on returning a `Html msg` not a `Html (Msg fieldMsg)` from the view function. We essentially move the `Cmd.map FieldChanged` into the view function:
```elm
-- Instead of:

view : Model -> H.Html Msg
view model = 
    let
        options = 
            ShortText.toOptions
                { theme = theme
                , ...
                , maybeInteractionConfig = Nothing
                }
    in
    ShortText.field.view options model.fontName -- H.Html (ShortField.Msg)
        -- Map outside `view`
        |> H.map ChangedAddFontField
```
```elm
-- We now do:

view : Model -> H.Html Msg
view model = 
    let
        options = 
            ShortText.toOptions
                { theme = theme
                , ...
                -- Map inside `view`
                , onChange = ChangedAddFontField
                , interaction = Interaction.onFocus (OnFocus AddFontField)
                }
    in
    ShortText.field.view options model.fontName
```

As @dhruvio pointed out, this makes the message handling much better since each branch of the `case` only has one responsibility:

```elm
-- Instead of:

type Field = AddFontField

type Msg = ChangedAddFontField ShortTextField.Msg  -- etc.

type alias Model = { currentField : Maybe Field } -- etc.

update msg model =
  case msg of
    ChangedAddFontField fieldMsg ->
        let 
            ( repayment, repaymentCmd, maybeInteraction ) =
                ShortText.field.update fieldMsg model.fontName
                   |> Triple.mapSecond (Cmd.map ChangedAddFontField)
        in
        -- This branch has to handle all the different interactions as well
        -- as the usual changes to the field
        case maybeInteraction of 
            Just Interaction.Focus ->
                 { model | currentField = Just field }
            _ ->
                 { model | fontName = fontName }
```

```elm
-- We now do:

type Field = AddFontField

type Msg = OnFocus Field | ChangedAddFontField ShortTextField.Msg  -- etc.

type alias Model = { currentField : Maybe Field } -- etc.

update msg model =
  case msg of
    -- Handle interaction and field updates separately
    OnFocus field -> { model | currentField = Just field }
    ChangedAddFontField msg_ ->
        let 
            ( repayment, repaymentCmd, maybeInteraction ) =
                ShortText.field.update fieldMsg model.fontName
                   |> Triple.mapSecond (Cmd.map ChangedAddFontField)
        in
        { model | fontName = fontName }
```