### PR TITLE
Fix LoadingSpinner appearance when there are multiple sizes on a page

### DIFF
--- a/src/Elemental/View/LoadingSpinner.elm
+++ b/src/Elemental/View/LoadingSpinner.elm
@@ -23,6 +23,19 @@ type Size
     | Large
 
 
+sizeToIdSuffix : Size -> String
+sizeToIdSuffix size =
+    case size of
+        Small ->
+            "-small"
+
+        Medium ->
+            "-medium"
+
+        Large ->
+            "-large"
+
+
 viewCustom : Options -> H.Html msg
 viewCustom options =
     let
@@ -79,6 +92,9 @@ viewCustom options =
         innerCursorRadius =
             innerStrokeWidth / 2
 
+        innerCursorOffset =
+            outerStrokeWidth / 2 + 1
+
         innerCursorRadius_ =
             String.fromFloat innerCursorRadius
 
@@ -89,10 +105,10 @@ viewCustom options =
             options.foreground.value
 
         gradientId =
-            "loading-spinner-gradient"
+            "loading-spinner-gradient" ++ sizeToIdSuffix options.size
 
         maskId =
-            "loading-spinner-mask"
+            "loading-spinner-mask" ++ sizeToIdSuffix options.size
     in
     Svg.svg
         [ SA.viewBox <| "0 0 " ++ w ++ " " ++ h
@@ -181,7 +197,7 @@ viewCustom options =
                 ]
             , Svg.circle
                 [ SA.cx half_
-                , SA.cy <| String.fromFloat <| dimension - 3
+                , SA.cy <| String.fromFloat <| dimension - innerCursorOffset
                 , SA.r innerCursorRadius_
                 , SA.fill foreground
                 ]


### PR DESCRIPTION
The `LoadingSpinner` view have an appearance errors when used after a different size spinner.
The `id` used to reference the mask and gradient ends up to pointing to the first spinner’s mask and gradient definitions.

I've fixed this by appending the size to the ids (`loading-spinner-mask-[small|medium|large]` instead of `loading-spinner-mask`)

| Before | After |
|---| ---|
| ![image](https://user-images.githubusercontent.com/28830783/221825914-33caf991-06b9-41d2-8068-78d6b2d7aa0c.png) | ![image](https://user-images.githubusercontent.com/28830783/221825978-975e68ca-5f87-4548-b7d4-f0e3107ca782.png)|